### PR TITLE
Adds idle time capping to macro playback

### DIFF
--- a/src/macro_py/MacroApp.py
+++ b/src/macro_py/MacroApp.py
@@ -18,6 +18,7 @@ class MacroApp:
         self.macro_data = []
         self.hotkey_listener = None
         self.running = True
+        self.max_idle_time = None  # Max seconds between events (None = no limit)
 
     def setup_hotkeys(self):
         """Configure global hotkeys for CLI mode (not used by GUI)."""
@@ -66,23 +67,49 @@ class MacroApp:
             self.macro_data = self.recorder.events.copy()
             print(f"Recorded {len(self.macro_data)} events")
 
+            # Diagnostic: show timing info to verify idle periods are captured
+            if self.macro_data:
+                # Filter out control events for timing analysis
+                timed_events = [
+                    e for e in self.macro_data
+                    if e.get("type") not in ("__stop_request__", "__system_message__")
+                    and isinstance(e.get("time"), (int, float))
+                ]
+                if timed_events:
+                    first_time = timed_events[0].get("time", 0)
+                    last_time = timed_events[-1].get("time", 0)
+                    duration = last_time - first_time
+                    print(f"⏱️ Timing: first={first_time:.2f}s, last={last_time:.2f}s, duration={duration:.2f}s")
+
     def play_once(self):
         """Play current macro once."""
         if self.macro_data and not self.player.playing:
             print("▶️ Playing macro once...")
-            Thread(target=self.player.play_macro, args=(self.macro_data, 1)).start()
+            Thread(
+                target=self.player.play_macro,
+                args=(self.macro_data, 1),
+                kwargs={"max_idle_time": self.max_idle_time},
+            ).start()
 
     def play_infinite(self):
         """Play current macro in an infinite loop (F5 to stop)."""
         if self.macro_data and not self.player.playing:
             print("🔁 Playing macro infinitely (F5 to stop)...")
-            Thread(target=self.player.play_macro, args=(self.macro_data, -1)).start()
+            Thread(
+                target=self.player.play_macro,
+                args=(self.macro_data, -1),
+                kwargs={"max_idle_time": self.max_idle_time},
+            ).start()
 
     def play_x_times(self, times):
         """Play current macro a fixed number of times."""
         if self.macro_data and not self.player.playing:
             print(f"🔄 Playing macro {times} times...")
-            Thread(target=self.player.play_macro, args=(self.macro_data, times)).start()
+            Thread(
+                target=self.player.play_macro,
+                args=(self.macro_data, times),
+                kwargs={"max_idle_time": self.max_idle_time},
+            ).start()
 
     def stop_playback(self):
         """Stop playback if currently playing."""

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -498,8 +498,8 @@ class MacroGUI(QMainWindow):
         self.max_idle_entry = QLineEdit("")
         self.max_idle_entry.setFixedWidth(60)
         self.max_idle_entry.setPlaceholderText("none")
-        self.max_idle_entry.setToolTip("Max delay between events during playback (empty = no limit)")
-        self.max_idle_entry.setValidator(QIntValidator(0, 999999, self))
+        self.max_idle_entry.setToolTip("Max delay between events during playback (empty = no limit, min 1)")
+        self.max_idle_entry.setValidator(QIntValidator(1, 999999, self))
         options_layout.addWidget(self.max_idle_entry)
 
         clear_log_btn = QPushButton("Clear Log")

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -262,7 +262,7 @@ class MacroGUI(QMainWindow):
         super().__init__()
         self.app = MacroApp()
         self.setWindowTitle("Macro Recorder")
-        self.setGeometry(100, 100, 480, 320)
+        self.setGeometry(100, 100, 620, 320)
         # Default to always-on-top
         self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
 
@@ -381,8 +381,19 @@ class MacroGUI(QMainWindow):
         toolbar.setMovable(False)
         toolbar.setIconSize(QSize(18, 18))
         self.addToolBar(toolbar)
-        # Visual separator for topbar
-        toolbar.setStyleSheet("QToolBar { border-bottom: 1px solid #c8c8c8; }")
+        # Visual separator for topbar + visible extension button
+        toolbar.setStyleSheet("""
+            QToolBar { border-bottom: 1px solid #c8c8c8; }
+            QToolButton#qt_toolbar_ext_button {
+                background: #666;
+                border-radius: 2px;
+                min-width: 16px;
+                padding: 2px;
+            }
+            QToolButton#qt_toolbar_ext_button:hover {
+                background: #888;
+            }
+        """)
 
         # Actions
         self.action_start_rec = QAction("Start", self)

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -29,7 +29,7 @@ from PyQt6.QtWidgets import (
     QMessageBox,
 )
 from PyQt6.QtCore import Qt, QTimer, QSize, QAbstractListModel, QModelIndex
-from PyQt6.QtGui import QKeySequence, QAction, QColor, QPalette
+from PyQt6.QtGui import QKeySequence, QAction, QColor, QPalette, QIntValidator
 from PyQt6.QtWidgets import QStyledItemDelegate
 from .MacroApp import MacroApp
 from pynput import keyboard
@@ -499,6 +499,7 @@ class MacroGUI(QMainWindow):
         self.max_idle_entry.setFixedWidth(60)
         self.max_idle_entry.setPlaceholderText("none")
         self.max_idle_entry.setToolTip("Max delay between events during playback (empty = no limit)")
+        self.max_idle_entry.setValidator(QIntValidator(0, 999999, self))
         options_layout.addWidget(self.max_idle_entry)
 
         clear_log_btn = QPushButton("Clear Log")

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -482,6 +482,14 @@ class MacroGUI(QMainWindow):
         self.activate_on_play_checkbox.setChecked(True)
         options_layout.addWidget(self.activate_on_play_checkbox)
 
+        # Max idle time setting (caps delays during playback)
+        options_layout.addWidget(QLabel("Max idle (ms):"))
+        self.max_idle_entry = QLineEdit("")
+        self.max_idle_entry.setFixedWidth(60)
+        self.max_idle_entry.setPlaceholderText("none")
+        self.max_idle_entry.setToolTip("Max delay between events during playback (empty = no limit)")
+        options_layout.addWidget(self.max_idle_entry)
+
         clear_log_btn = QPushButton("Clear Log")
         clear_log_btn.clicked.connect(self.clear_log)
         options_layout.addWidget(clear_log_btn)
@@ -1049,6 +1057,17 @@ class MacroGUI(QMainWindow):
 
     def _prepare_for_playback(self):
         """Lower window, manage top-most state, and enable F5 stop hotkey."""
+        # Parse max idle time from GUI and pass to app
+        max_idle_text = self.max_idle_entry.text().strip()
+        if max_idle_text:
+            try:
+                # Convert ms to seconds for the player
+                self.app.max_idle_time = int(max_idle_text) / 1000.0
+            except ValueError:
+                self.app.max_idle_time = None
+        else:
+            self.app.max_idle_time = None
+
         # Send window to background and manage always-on-top, then enable F5 stop
         if self.isVisible():
             if self.always_on_top_action.isChecked():

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -860,9 +860,10 @@ class MacroGUI(QMainWindow):
 
     def on_always_on_top_toggled(self, checked):
         """Apply the always-on-top flag and re-show the window to take effect."""
+        was_visible = self.isVisible()
         self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, checked)
-        # Re-show to apply flag change on macOS/Qt
-        if self.isVisible():
+        # setWindowFlag hides the window, so re-show it
+        if was_visible:
             self.show()
 
     def _toggle_log_from_action(self, checked):

--- a/src/macro_py/MacroGUI.py
+++ b/src/macro_py/MacroGUI.py
@@ -1075,7 +1075,9 @@ class MacroGUI(QMainWindow):
         if max_idle_text:
             try:
                 # Convert ms to seconds for the player
-                self.app.max_idle_time = int(max_idle_text) / 1000.0
+                ms_value = int(max_idle_text)
+                # Treat negative or zero as no limit
+                self.app.max_idle_time = ms_value / 1000.0 if ms_value > 0 else None
             except ValueError:
                 self.app.max_idle_time = None
         else:

--- a/src/macro_py/MacroPlayer.py
+++ b/src/macro_py/MacroPlayer.py
@@ -28,6 +28,9 @@ class MacroPlayer:
         - speed: playback speed multiplier (e.g., 2.0 = double speed)
         - max_idle_time: max seconds to wait between events (None = no limit)
         """
+        # Normalize to list to support generators and allow multiple iterations
+        events = list(events)
+
         self.playing = True
         self.stop_flag = False
         self.current_loop = 0

--- a/src/macro_py/MacroPlayer.py
+++ b/src/macro_py/MacroPlayer.py
@@ -20,17 +20,27 @@ class MacroPlayer:
         self.current_loop = 0
         self.total_loops = 0  # -1 for infinite
 
-    def play_macro(self, events, loops=1, speed=1.0):
+    def play_macro(self, events, loops=1, speed=1.0, max_idle_time=None):
         """Play a list of recorded events.
 
         - events: iterable of event dicts with 'type' and 'time' fields
         - loops: number of repetitions (-1 for infinite)
         - speed: playback speed multiplier (e.g., 2.0 = double speed)
+        - max_idle_time: max seconds to wait between events (None = no limit)
         """
         self.playing = True
         self.stop_flag = False
         self.current_loop = 0
         self.total_loops = loops
+
+        # Find the recording end time from __stop_request__ event (if present)
+        recording_end_time = None
+        for event in events:
+            if event.get("type") == "__stop_request__":
+                t = event.get("time")
+                if isinstance(t, (int, float)):
+                    recording_end_time = t
+                break
 
         loop_count = 0
         while (loops == -1 or loop_count < loops) and not self.stop_flag:
@@ -55,12 +65,23 @@ class MacroPlayer:
 
                 # Wait for the appropriate time
                 wait_time = (event_time - last_time) / speed
+                # Cap wait time if max_idle_time is set
+                if max_idle_time is not None and wait_time > max_idle_time:
+                    wait_time = max_idle_time
                 if wait_time > 0:
                     time.sleep(wait_time)
                 last_time = event_time
 
                 # Execute the event
                 self.execute_event(event)
+
+            # Wait for final idle period before next loop (time from last event to F2 press)
+            if not self.stop_flag and recording_end_time is not None and last_time < recording_end_time:
+                final_wait = (recording_end_time - last_time) / speed
+                if max_idle_time is not None and final_wait > max_idle_time:
+                    final_wait = max_idle_time
+                if final_wait > 0:
+                    time.sleep(final_wait)
 
             loop_count += 1
 


### PR DESCRIPTION
Adds functionality to limit the maximum delay between macro events during playback. This prevents excessively long pauses if the recorded macro had extended idle periods.

How to Test:
1. Record a macro with long pauses.
2. Set a "Max idle (ms)" value in the GUI.
3. Playback the macro and observe that the pauses are capped.
Include before/after screenshots or GIFs of the GUI.

Review Focus:
- Verify the idle time capping logic.
- Ensure that the new GUI element integrates correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Max idle time" option (ms) in Options with integer validation and placeholder; value is applied to playback.

* **Bug Fixes / Reliability**
  * Playback now respects the Max idle time, capping long idle gaps and avoiding unbounded waits.
  * Final idle wait refined to skip when appropriate.

* **Style**
  * Window widened for improved spacing.
  * Toolbar controls restyled with visible extension and hover effects.
  * Always-on-top toggle preserves prior visibility.

* **Diagnostics**
  * Recording stop now prints timing statistics for non-control events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->